### PR TITLE
Disable spell checking in comment blocks.

### DIFF
--- a/syntax/hgcommit.vim
+++ b/syntax/hgcommit.vim
@@ -10,12 +10,12 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn match hgcommitComment "^HG:.*$"
-syn match hgcommitUser    "^HG: user: \zs.*$"   contained containedin=hgcommitComment
-syn match hgcommitBranch  "^HG: branch \zs.*$"  contained containedin=hgcommitComment
-syn match hgcommitAdded   "^HG: \zsadded .*$"   contained containedin=hgcommitComment
-syn match hgcommitChanged "^HG: \zschanged .*$" contained containedin=hgcommitComment
-syn match hgcommitRemoved "^HG: \zsremoved .*$" contained containedin=hgcommitComment
+syn match hgcommitComment "^HG:.*$"             contains=@NoSpell
+syn match hgcommitUser    "^HG: user: \zs.*$"   contains=@NoSpell contained containedin=hgcommitComment
+syn match hgcommitBranch  "^HG: branch \zs.*$"  contains=@NoSpell contained containedin=hgcommitComment
+syn match hgcommitAdded   "^HG: \zsadded .*$"   contains=@NoSpell contained containedin=hgcommitComment
+syn match hgcommitChanged "^HG: \zschanged .*$" contains=@NoSpell contained containedin=hgcommitComment
+syn match hgcommitRemoved "^HG: \zsremoved .*$" contains=@NoSpell contained containedin=hgcommitComment
 
 hi def link hgcommitComment Comment
 hi def link hgcommitUser    String


### PR DESCRIPTION
Hi, this change disables spell checking in comment blocks of Mercurial commit message.
